### PR TITLE
Replaced binary opentok-android-sdk-2.8.1.aar with maven dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ And those to root build.gradle allprojects:
     repositories {
         maven { url "https://jitpack.io" }
         maven { url 'http://download.crashlytics.com/maven' }
+        maven { url 'http://tokbox.bintray.com/maven' }
     }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,5 +16,6 @@ allprojects {
     repositories {
         jcenter()
         maven { url 'http://download.crashlytics.com/maven' }
+        maven { url 'http://tokbox.bintray.com/maven' }
     }
 }

--- a/idvos/build.gradle
+++ b/idvos/build.gradle
@@ -31,7 +31,7 @@ artifacts {
 }
 
 dependencies {
-    compile project(':opentok-android-sdk-2.8.1')
+    compile 'com.opentok.android:opentok-android-sdk:2.8.1-REL-1785'
     compile 'com.mcxiaoke.volley:library:1.0.19'
     compile 'com.pusher:pusher-java-client:0.3.1'
     compile 'com.android.support:support-v4:21.0.3'

--- a/opentok-android-sdk-2.8.1/build.gradle
+++ b/opentok-android-sdk-2.8.1/build.gradle
@@ -1,2 +1,0 @@
-configurations.create("default")
-artifacts.add("default", file('opentok-android-sdk-2.8.1.aar'))

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,2 @@
-include ':example', ':idvos-app', ':opentok-android-sdk-2.8.1'
+include ':example', ':idvos-app'
 include ':idvos'


### PR DESCRIPTION
This way it's not necessary to include the opentok module in app including the idvos sdk.
